### PR TITLE
[codex] Deepen site narrative and visual impact

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,7 +88,7 @@ button, a, input, select, textarea {
 }
 
 section[id] {
-  scroll-margin-top: 5rem;
+  scroll-margin-top: 0;
 }
 
 .font-serif {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -9,7 +9,7 @@ export const metadata = {
   metadataBase: new URL(siteUrl),
   applicationName: siteName,
   title: {
-    default: `${siteName} | Verifiable AI Infrastructure`,
+    default: `${siteName} | Accountable AI Infrastructure`,
     template: `%s | ${siteName}`,
   },
   description: siteDescription,
@@ -28,7 +28,7 @@ export const metadata = {
     'crypto market structure',
   ],
   openGraph: {
-    title: `${siteName} | Verifiable AI Infrastructure`,
+    title: `${siteName} | Accountable AI Infrastructure`,
     description: siteDescription,
     url: siteUrl,
     siteName,
@@ -38,7 +38,7 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     creator: '@advait_jayant',
-    title: `${siteName} | Verifiable AI Infrastructure`,
+    title: `${siteName} | Accountable AI Infrastructure`,
     description: siteDescription,
   },
   robots: {

--- a/src/app/opengraph-image.js
+++ b/src/app/opengraph-image.js
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 
-export const alt = 'Advait Jayant — verifiable AI infrastructure';
+export const alt = 'Advait Jayant — accountable AI infrastructure';
 export const size = {
   width: 1200,
   height: 630,
@@ -42,7 +42,7 @@ export default function Image() {
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
           <div style={{ fontSize: 104, lineHeight: 0.98, maxWidth: 900 }}>
-            Verifiable AI infrastructure.
+            Accountable AI infrastructure.
           </div>
           <div style={{ display: 'flex', gap: 12 }}>
             <div style={{ width: 128, height: 6, background: '#2446c7' }} />
@@ -57,7 +57,7 @@ export default function Image() {
             lineHeight: 1.35,
           }}
         >
-          For agents that touch money, memory, and markets.
+          Proofs, memory, and settlement for agents that do real work.
         </div>
       </div>
     ),

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,6 +3,7 @@ import Hero from '@/components/Hero';
 import ProofStrip from '@/components/ProofStrip';
 import Thesis from '@/components/Thesis';
 import About from '@/components/About';
+import ImpactLedger from '@/components/ImpactLedger';
 import StackDiagram from '@/components/StackDiagram';
 import Experience from '@/components/Experience';
 import Work from '@/components/Work';
@@ -21,6 +22,7 @@ export default function Home() {
         <ProofStrip />
         <Thesis />
         <About />
+        <ImpactLedger />
         <StackDiagram />
         <Experience />
         <Work />

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -13,6 +13,21 @@ const outcomes = [
   { k: 'Launches', v: '1K+', d: 'Korea event attendees in a week' },
 ];
 
+const modes = [
+  {
+    k: 'Translate',
+    v: 'Make frontier systems understandable without flattening the technical truth.',
+  },
+  {
+    k: 'Ship',
+    v: 'Move from thesis to working product, customer proof, and revenue.',
+  },
+  {
+    k: 'Distribute',
+    v: 'Give technical infrastructure a narrative surface the market can remember.',
+  },
+];
+
 export default function About() {
   return (
     <section id="about" className="section-band relative py-16 sm:py-24 md:py-32 lg:py-40 border-t border-border">
@@ -36,6 +51,21 @@ export default function About() {
               </div>
             ))}
           </dl>
+        </Reveal>
+
+        <Reveal delay={0.04}>
+          <div className="mt-8 grid gap-4 sm:grid-cols-3">
+            {modes.map((mode) => (
+              <div key={mode.k} className="border border-border bg-surface px-5 py-5">
+                <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                  {mode.k}
+                </div>
+                <p className="mt-3 font-serif text-[16px] leading-[1.5] text-fg-muted">
+                  {mode.v}
+                </p>
+              </div>
+            ))}
+          </div>
         </Reveal>
 
         <div className="mt-16 sm:mt-20 md:mt-24 grid gap-14 lg:grid-cols-[minmax(0,680px)_280px] lg:gap-20 lg:items-start">

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -16,7 +16,7 @@ const outcomes = [
 const modes = [
   {
     k: 'Translate',
-    v: 'Make frontier systems understandable without flattening the technical truth.',
+    v: 'Make deeply technical systems understandable without watering them down.',
   },
   {
     k: 'Ship',
@@ -24,7 +24,7 @@ const modes = [
   },
   {
     k: 'Distribute',
-    v: 'Give technical infrastructure a narrative surface the market can remember.',
+    v: 'Give technical work a story people actually remember.',
   },
 ];
 

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -19,7 +19,7 @@ const collaboration = [
   },
   {
     k: 'Tell',
-    v: 'Technical narratives, launch films, talks, and category creation.',
+    v: 'Technical narratives, launch films, talks, and explaining new categories.',
   },
 ];
 

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Reveal from './Reveal';
 
 const channels = [
@@ -36,19 +37,43 @@ export default function Contact() {
         </Reveal>
 
         <Reveal delay={0.05}>
-          <h2 className="font-serif text-5xl sm:text-6xl md:text-7xl lg:text-[104px] leading-[0.98] text-fg max-w-4xl text-balance">
-            Let&apos;s <span className="italic text-accent">talk.</span>
-          </h2>
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_360px] lg:items-end lg:gap-16">
+            <div>
+              <h2 className="font-serif text-5xl leading-[0.98] text-fg text-balance sm:text-6xl md:text-7xl lg:text-[104px]">
+                Let&apos;s <span className="italic text-accent">talk.</span>
+              </h2>
+              <p className="mt-6 max-w-xl font-serif text-lg italic leading-relaxed text-fg-muted sm:mt-8 sm:text-xl">
+                If you&apos;re building verifiable AI infrastructure, agent memory, crypto rails,
+                or anything where trust boundaries matter, drop me a line.
+              </p>
+            </div>
+
+            <aside
+              aria-label="Contact note"
+              className="relative min-h-[240px] overflow-hidden rounded-[3px] border border-border bg-fg shadow-[0_22px_70px_rgba(29,37,40,0.08)] sm:min-h-[300px]"
+            >
+              <Image
+                src="/images/ascii_bg.gif"
+                alt=""
+                fill
+                unoptimized
+                sizes="(min-width: 1024px) 360px, 100vw"
+                className="object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-b from-fg/15 via-fg/20 to-fg/78" />
+              <div className="absolute inset-x-0 bottom-0 p-5 sm:p-6">
+                <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/70">
+                  Usually async first
+                </div>
+                <p className="mt-3 max-w-[18rem] font-serif text-[21px] leading-[1.18] text-white sm:text-[24px]">
+                  Send the sharp version of the problem. I&apos;ll read it properly.
+                </p>
+              </div>
+            </aside>
+          </div>
         </Reveal>
 
-        <Reveal delay={0.12}>
-          <p className="mt-6 sm:mt-8 max-w-xl font-serif italic text-lg sm:text-xl leading-relaxed text-fg-muted">
-            If you&apos;re building verifiable AI infrastructure, agent memory, crypto rails, or
-            anything where trust boundaries matter, drop me a line.
-          </p>
-        </Reveal>
-
-        <Reveal delay={0.2}>
+        <Reveal delay={0.14}>
           <div className="mt-10 grid gap-4 sm:grid-cols-3">
             {collaboration.map((item) => (
               <div key={item.k} className="border border-border bg-bg px-5 py-5">
@@ -63,7 +88,7 @@ export default function Contact() {
           </div>
         </Reveal>
 
-        <Reveal delay={0.24}>
+        <Reveal delay={0.18}>
           <ul className="mt-12 sm:mt-16">
             {channels.map((c) => (
               <li key={c.k} className="border-t border-border last:border-b">

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -8,13 +8,28 @@ const channels = [
   { k: 'Twitter / X', v: '@advait_jayant', href: 'https://x.com/advait_jayant' },
 ];
 
+const collaboration = [
+  {
+    k: 'Build',
+    v: 'Verifiable AI infra, agent memory, decentralized compute, product strategy.',
+  },
+  {
+    k: 'Think',
+    v: 'Research, market maps, crypto rails, AI x capital formation.',
+  },
+  {
+    k: 'Tell',
+    v: 'Technical narratives, launch films, talks, and category creation.',
+  },
+];
+
 export default function Contact() {
   return (
     <section id="contact" className="relative py-16 sm:py-24 md:py-32 lg:py-44 border-t border-border bg-surface/35">
       <div className="mx-auto max-w-6xl px-5 sm:px-8">
         <Reveal>
           <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-accent flex items-center gap-3 mb-8 sm:mb-10">
-            <span>06</span>
+            <span>07</span>
             <span className="h-px w-10 bg-accent/40" />
             <span className="text-fg-dim">Contact</span>
           </div>
@@ -34,6 +49,21 @@ export default function Contact() {
         </Reveal>
 
         <Reveal delay={0.2}>
+          <div className="mt-10 grid gap-4 sm:grid-cols-3">
+            {collaboration.map((item) => (
+              <div key={item.k} className="border border-border bg-bg px-5 py-5">
+                <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                  {item.k}
+                </div>
+                <p className="mt-3 font-serif text-[15px] leading-[1.5] text-fg-muted">
+                  {item.v}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Reveal>
+
+        <Reveal delay={0.24}>
           <ul className="mt-12 sm:mt-16">
             {channels.map((c) => (
               <li key={c.k} className="border-t border-border last:border-b">

--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -86,7 +86,7 @@ export default function Experience() {
         <SectionHeader
           index="04"
           title="Experience"
-          lede="A track record across product, research, capital, and go-to-market when the category is still forming."
+          lede="Product, research, capital, and go-to-market work while the market is still taking shape."
         />
 
         <ol>

--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -32,6 +32,7 @@ const roles = [
         verifiable memory layer for agents across Claude, ChatGPT, Gemini, and open-source models.
       </>
     ),
+    highlights: ['7-figure product revenue', '4,500+ hosted models', '500K+ proofs'],
   },
   {
     period: '2022 — 2025',
@@ -66,6 +67,7 @@ const roles = [
         accuracy. 30+ enterprise pilots. First author of The State of Edge AI. IP acquired.
       </>
     ),
+    highlights: ['$1.5M raised', '200K+ users', '30+ pilots'],
   },
   {
     period: '2019 — 2022',
@@ -73,6 +75,7 @@ const roles = [
     href: null,
     title: 'Technical Author',
     body: '50+ technical publications on AI — neural networks, NLP, transfer learning, big-data infrastructure. Featured in O’Reilly Safari Books Online. 15K+ readers.',
+    highlights: ['50+ publications', '15K+ readers', 'O’Reilly Safari'],
   },
 ];
 
@@ -81,9 +84,9 @@ export default function Experience() {
     <section id="experience" className="relative py-16 sm:py-24 md:py-32 lg:py-40 border-t border-border">
       <div className="mx-auto max-w-6xl px-5 sm:px-8">
         <SectionHeader
-          index="03"
+          index="04"
           title="Experience"
-          lede="A track record across product, research, capital, and go-to-market."
+          lede="A track record across product, research, capital, and go-to-market when the category is still forming."
         />
 
         <ol>
@@ -117,6 +120,16 @@ export default function Experience() {
                   <p className="mt-3 sm:mt-4 max-w-2xl font-serif text-[15px] sm:text-base leading-[1.65] text-fg-muted">
                     {r.body}
                   </p>
+                  <ul className="mt-5 flex flex-wrap gap-2">
+                    {r.highlights.map((highlight) => (
+                      <li
+                        key={highlight}
+                        className="rounded-[2px] border border-border bg-bg px-2.5 py-1.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-fg-dim"
+                      >
+                        {highlight}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               </li>
             </Reveal>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { motion, useReducedMotion } from 'motion/react';
 
 const focus = [
@@ -7,6 +8,8 @@ const focus = [
   ['02', 'Portable memory for agents'],
   ['03', 'Settlement for agent actions'],
 ];
+
+const signals = ['AI infra', 'crypto rails', 'technical media'];
 
 export default function Hero() {
   const shouldReduceMotion = useReducedMotion();
@@ -28,7 +31,7 @@ export default function Hero() {
       <div className="dot-field" aria-hidden />
 
       <div className="relative z-10 mx-auto max-w-6xl px-5 sm:px-8">
-        <div className="min-h-[88svh] sm:min-h-[92svh] grid items-center gap-12 pt-28 pb-14 sm:pt-36 sm:pb-20 lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-16">
+        <div className="grid min-h-[88svh] items-center gap-12 pb-14 pt-28 sm:min-h-[92svh] sm:pb-20 sm:pt-36 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.62fr)] lg:gap-16">
           <div className="min-w-0">
             <motion.div
               {...fadeUp(10, 0, 0.75)}
@@ -51,8 +54,8 @@ export default function Hero() {
               className="mt-8 sm:mt-10 max-w-2xl font-serif text-lg sm:text-xl md:text-[22px] leading-[1.55] text-fg space-y-3"
             >
               <p>
-                I build verifiable AI infrastructure for agents that touch money, memory, and
-                markets.
+                I build the trust layer for AI agents that are about to touch money, memory,
+                identity, and institutional workflows.
               </p>
               <p>
                 At{' '}
@@ -65,9 +68,10 @@ export default function Hero() {
                 >
                   OpenGradient
                 </a>
-                , I lead product strategy, ecosystem growth, and customer engineering across a
+                , I lead product strategy, ecosystem growth, and customer engineering across the
                 decentralized GPU + TEE inference network and MemSync, a portable memory layer for
-                agents. I also write research and{' '}
+                agents. The job is to make frontier infrastructure legible enough to buy, trust,
+                and build on. I also write research and{' '}
                 <a href="#work" className="text-accent hover:underline underline-offset-[3px]">
                   produce films
                 </a>
@@ -80,42 +84,77 @@ export default function Hero() {
               className="mt-10 sm:mt-12 flex flex-wrap items-center gap-x-7 gap-y-3 font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.12em]"
             >
               <a href="#thesis" className="text-fg-muted hover:text-accent transition-colors inline-flex items-center gap-1.5 border-b border-transparent hover:border-accent">
-                Read the thesis <span aria-hidden>↓</span>
+                Read the operating thesis <span aria-hidden>↓</span>
               </a>
               <span aria-hidden className="text-fg-faint">·</span>
-              <a href="#experience" className="text-fg-muted hover:text-accent transition-colors border-b border-transparent hover:border-accent">Experience</a>
+              <a href="#impact" className="text-fg-muted hover:text-accent transition-colors border-b border-transparent hover:border-accent">See receipts</a>
               <span aria-hidden className="text-fg-faint">·</span>
               <a href="#work" className="text-fg-muted hover:text-accent transition-colors border-b border-transparent hover:border-accent">Work</a>
-              <span aria-hidden className="text-fg-faint">·</span>
-              <a href="#contact" className="text-fg-muted hover:text-accent transition-colors inline-flex items-center gap-1.5 border-b border-transparent hover:border-accent">
-                Get in touch <span aria-hidden>→</span>
-              </a>
             </motion.div>
           </div>
 
           <motion.aside
             {...fadeUp(14, 0.42, 0.8)}
-            aria-label="Current focus and selected outcomes"
-            className="border-y border-border py-6 sm:py-7 lg:mt-24"
+            aria-label="Current focus"
+            className="relative overflow-hidden rounded-[3px] border border-border bg-surface shadow-[0_24px_80px_rgba(29,37,40,0.08)] lg:mt-20"
           >
-            <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-accent">
-              Current focus
+            <div className="relative h-48 overflow-hidden border-b border-border sm:h-56">
+              <Image
+                src="/images/ascii_bg.gif"
+                alt=""
+                fill
+                priority
+                unoptimized
+                sizes="(min-width: 1024px) 390px, 100vw"
+                className="object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-b from-bg/10 via-bg/10 to-bg/80" />
+              <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-4 p-5">
+                <div>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                    Current operating zone
+                  </div>
+                  <p className="mt-2 max-w-[17rem] font-serif text-[22px] leading-[1.1] text-fg">
+                    Accountable agents, not smarter chat windows.
+                  </p>
+                </div>
+                <span className="hidden rounded-[2px] border border-border bg-surface/80 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-accent sm:inline-flex">
+                  2026
+                </span>
+              </div>
             </div>
-            <ul className="mt-5 divide-y divide-border-soft">
-              {focus.map(([num, label]) => (
-                <li key={label} className="grid grid-cols-[2.5rem_1fr] items-baseline gap-4 py-3">
-                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt">
-                    {num}
-                  </span>
-                  <span className="font-serif text-[17px] leading-snug text-fg">{label}</span>
-                </li>
-              ))}
-            </ul>
 
-            <p className="mt-7 border-l border-accent/35 pl-4 font-serif text-[16px] leading-[1.55] text-fg-muted">
-              The through-line: execution you can prove, memory users can carry, and settlement
-              nobody can quietly rewrite.
-            </p>
+            <div className="p-5 sm:p-6">
+              <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-accent">
+                Current focus
+              </div>
+              <ul className="mt-5 divide-y divide-border-soft">
+                {focus.map(([num, label]) => (
+                  <li key={label} className="grid grid-cols-[2.5rem_1fr] items-baseline gap-4 py-3">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt">
+                      {num}
+                    </span>
+                    <span className="font-serif text-[17px] leading-snug text-fg">{label}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-6 flex flex-wrap gap-2">
+                {signals.map((signal) => (
+                  <span
+                    key={signal}
+                    className="rounded-[2px] border border-border bg-bg px-2.5 py-1.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-fg-muted"
+                  >
+                    {signal}
+                  </span>
+                ))}
+              </div>
+
+              <p className="mt-6 border-l border-accent/35 pl-4 font-serif text-[16px] leading-[1.55] text-fg-muted">
+                The through-line: execution you can prove, memory users can carry, and settlement
+                nobody can quietly rewrite.
+              </p>
+            </div>
           </motion.aside>
         </div>
       </div>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,15 +1,23 @@
 'use client';
 
-import Image from 'next/image';
 import { motion, useReducedMotion } from 'motion/react';
 
-const focus = [
-  ['01', 'Proofs for AI execution'],
-  ['02', 'Portable memory for agents'],
-  ['03', 'Settlement for agent actions'],
+const signals = ['proofs for AI execution', 'portable memory', 'agent settlement'];
+
+const pipeline = [
+  { k: 'Request', v: 'intent + context' },
+  { k: 'Memory', v: 'portable state' },
+  { k: 'Execute', v: 'GPU + TEE' },
+  { k: 'Prove', v: 'signed receipt' },
+  { k: 'Settle', v: 'external record' },
 ];
 
-const signals = ['AI infra', 'crypto rails', 'technical media'];
+const receipt = [
+  ['model', 'open model'],
+  ['enclave', 'attested'],
+  ['proof', 'ed25519'],
+  ['state', 'committed'],
+];
 
 export default function Hero() {
   const shouldReduceMotion = useReducedMotion();
@@ -31,7 +39,7 @@ export default function Hero() {
       <div className="dot-field" aria-hidden />
 
       <div className="relative z-10 mx-auto max-w-6xl px-5 sm:px-8">
-        <div className="grid min-h-[88svh] items-center gap-12 pb-14 pt-28 sm:min-h-[92svh] sm:pb-20 sm:pt-36 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.62fr)] lg:gap-16">
+        <div className="grid min-h-[86svh] items-center gap-12 pb-6 pt-24 sm:min-h-[90svh] sm:pb-8 sm:pt-30 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.62fr)] lg:gap-16">
           <div className="min-w-0">
             <motion.div
               {...fadeUp(10, 0, 0.75)}
@@ -96,50 +104,15 @@ export default function Hero() {
           <motion.aside
             {...fadeUp(14, 0.42, 0.8)}
             aria-label="Current focus"
-            className="relative overflow-hidden rounded-[3px] border border-border bg-surface shadow-[0_24px_80px_rgba(29,37,40,0.08)] lg:mt-20"
+            className="relative overflow-hidden rounded-[3px] border border-border bg-surface shadow-[0_24px_80px_rgba(29,37,40,0.08)] lg:mt-12"
           >
-            <div className="relative h-48 overflow-hidden border-b border-border sm:h-56">
-              <Image
-                src="/images/ascii_bg.gif"
-                alt=""
-                fill
-                priority
-                unoptimized
-                sizes="(min-width: 1024px) 390px, 100vw"
-                className="object-cover"
-              />
-              <div className="absolute inset-0 bg-gradient-to-b from-bg/10 via-bg/10 to-bg/80" />
-              <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-4 p-5">
-                <div>
-                  <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-                    Current operating zone
-                  </div>
-                  <p className="mt-2 max-w-[17rem] font-serif text-[22px] leading-[1.1] text-fg">
-                    Accountable agents, not smarter chat windows.
-                  </p>
-                </div>
-                <span className="hidden rounded-[2px] border border-border bg-surface/80 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-accent sm:inline-flex">
-                  2026
-                </span>
-              </div>
-            </div>
+            <HeroSystemPanel />
 
             <div className="p-5 sm:p-6">
               <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-accent">
-                Current focus
+                Operating lanes
               </div>
-              <ul className="mt-5 divide-y divide-border-soft">
-                {focus.map(([num, label]) => (
-                  <li key={label} className="grid grid-cols-[2.5rem_1fr] items-baseline gap-4 py-3">
-                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt">
-                      {num}
-                    </span>
-                    <span className="font-serif text-[17px] leading-snug text-fg">{label}</span>
-                  </li>
-                ))}
-              </ul>
-
-              <div className="mt-6 flex flex-wrap gap-2">
+              <div className="mt-4 flex flex-wrap gap-2">
                 {signals.map((signal) => (
                   <span
                     key={signal}
@@ -150,7 +123,7 @@ export default function Hero() {
                 ))}
               </div>
 
-              <p className="mt-6 border-l border-accent/35 pl-4 font-serif text-[16px] leading-[1.55] text-fg-muted">
+              <p className="mt-5 border-l border-accent/35 pl-4 font-serif text-[15px] leading-[1.5] text-fg-muted">
                 The through-line: execution you can prove, memory users can carry, and settlement
                 nobody can quietly rewrite.
               </p>
@@ -159,5 +132,76 @@ export default function Hero() {
         </div>
       </div>
     </section>
+  );
+}
+
+function HeroSystemPanel() {
+  return (
+    <div className="relative overflow-hidden border-b border-border bg-[linear-gradient(135deg,#ffffff_0%,#f7f7f2_46%,#edf3ff_100%)] p-5">
+      <div
+        aria-hidden
+        className="absolute inset-0 opacity-70 [background-image:linear-gradient(to_right,rgba(36,70,199,0.08)_1px,transparent_1px),linear-gradient(to_bottom,rgba(15,118,110,0.07)_1px,transparent_1px)] [background-size:24px_24px]"
+      />
+      <div
+        aria-hidden
+        className="absolute -right-12 -top-16 h-44 w-44 rounded-full border border-accent/20 bg-accent-soft/60"
+      />
+      <div
+        aria-hidden
+        className="absolute -bottom-20 left-8 h-44 w-44 rounded-full border border-accent-alt/15 bg-surface/60"
+      />
+
+      <div className="relative z-10 flex items-center justify-between gap-4">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+            Agent action receipt
+          </div>
+          <p className="mt-2 max-w-[18rem] font-serif text-[22px] leading-[1.08] text-fg">
+            Accountable agents, not smarter chat windows.
+          </p>
+        </div>
+        <span className="hidden rounded-[2px] border border-border bg-surface/90 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-accent sm:inline-flex">
+          2026
+        </span>
+      </div>
+
+      <div className="relative z-10 mt-5 grid gap-2">
+        {pipeline.map((step, index) => (
+          <div
+            key={step.k}
+            className="grid grid-cols-[2.1rem_minmax(0,1fr)_auto] items-center gap-3 rounded-[2px] border border-border bg-surface/82 px-3 py-2 shadow-[0_1px_0_rgba(29,37,40,0.03)]"
+          >
+            <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-accent-alt">
+              {String(index + 1).padStart(2, '0')}
+            </span>
+            <div className="min-w-0">
+              <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
+                {step.k}
+              </div>
+              <div className="mt-0.5 truncate font-serif text-[13px] leading-tight text-fg-muted">
+                {step.v}
+              </div>
+            </div>
+            <span
+              aria-hidden
+              className={`h-2 w-2 rounded-full ${index === 3 ? 'bg-accent' : 'bg-accent-alt/60'}`}
+            />
+          </div>
+        ))}
+      </div>
+
+      <dl className="relative z-10 mt-4 grid grid-cols-2 gap-2">
+        {receipt.map(([k, v]) => (
+          <div key={k} className="border-y border-border bg-bg/70 px-3 py-2">
+            <dt className="font-mono text-[8.5px] uppercase tracking-[0.14em] text-fg-dim">
+              {k}
+            </dt>
+            <dd className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-fg-muted">
+              {v}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
   );
 }

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -8,11 +8,11 @@ const pipeline = [
   { k: 'Request', v: 'intent + context' },
   { k: 'Memory', v: 'portable state' },
   { k: 'Execute', v: 'GPU + TEE' },
-  { k: 'Prove', v: 'signed receipt' },
+  { k: 'Prove', v: 'signed output' },
   { k: 'Settle', v: 'external record' },
 ];
 
-const receipt = [
+const auditItems = [
   ['model', 'open model'],
   ['enclave', 'attested'],
   ['proof', 'ed25519'],
@@ -62,7 +62,7 @@ export default function Hero() {
               className="mt-8 sm:mt-10 max-w-2xl font-serif text-lg sm:text-xl md:text-[22px] leading-[1.55] text-fg space-y-3"
             >
               <p>
-                I build the trust layer for AI agents that are about to touch money, memory,
+                I build infrastructure for AI agents that are about to touch money, memory,
                 identity, and institutional workflows.
               </p>
               <p>
@@ -78,8 +78,8 @@ export default function Hero() {
                 </a>
                 , I lead product strategy, ecosystem growth, and customer engineering across the
                 decentralized GPU + TEE inference network and MemSync, a portable memory layer for
-                agents. The job is to make frontier infrastructure legible enough to buy, trust,
-                and build on. I also write research and{' '}
+                agents. I work on the parts that make this stack easier to buy, trust, and build
+                on. I also write research and{' '}
                 <a href="#work" className="text-accent hover:underline underline-offset-[3px]">
                   produce films
                 </a>
@@ -92,10 +92,10 @@ export default function Hero() {
               className="mt-10 sm:mt-12 flex flex-wrap items-center gap-x-7 gap-y-3 font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.12em]"
             >
               <a href="#thesis" className="text-fg-muted hover:text-accent transition-colors inline-flex items-center gap-1.5 border-b border-transparent hover:border-accent">
-                Read the operating thesis <span aria-hidden>↓</span>
+                Read the thesis <span aria-hidden>↓</span>
               </a>
               <span aria-hidden className="text-fg-faint">·</span>
-              <a href="#impact" className="text-fg-muted hover:text-accent transition-colors border-b border-transparent hover:border-accent">See receipts</a>
+              <a href="#impact" className="text-fg-muted hover:text-accent transition-colors border-b border-transparent hover:border-accent">Track record</a>
               <span aria-hidden className="text-fg-faint">·</span>
               <a href="#work" className="text-fg-muted hover:text-accent transition-colors border-b border-transparent hover:border-accent">Work</a>
             </motion.div>
@@ -110,7 +110,7 @@ export default function Hero() {
 
             <div className="p-5 sm:p-6">
               <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-accent">
-                Operating lanes
+                Current work
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
                 {signals.map((signal) => (
@@ -124,8 +124,8 @@ export default function Hero() {
               </div>
 
               <p className="mt-5 border-l border-accent/35 pl-4 font-serif text-[15px] leading-[1.5] text-fg-muted">
-                The through-line: execution you can prove, memory users can carry, and settlement
-                nobody can quietly rewrite.
+                The work is direct: prove execution, let users carry memory, and settle actions
+                where the operator cannot quietly rewrite them.
               </p>
             </div>
           </motion.aside>
@@ -154,7 +154,7 @@ function HeroSystemPanel() {
       <div className="relative z-10 flex items-center justify-between gap-4">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-            Agent action receipt
+            Agent audit trail
           </div>
           <p className="mt-2 max-w-[18rem] font-serif text-[22px] leading-[1.08] text-fg">
             Accountable agents, not smarter chat windows.
@@ -191,7 +191,7 @@ function HeroSystemPanel() {
       </div>
 
       <dl className="relative z-10 mt-4 grid grid-cols-2 gap-2">
-        {receipt.map(([k, v]) => (
+        {auditItems.map(([k, v]) => (
           <div key={k} className="border-y border-border bg-bg/70 px-3 py-2">
             <dt className="font-mono text-[8.5px] uppercase tracking-[0.14em] text-fg-dim">
               {k}

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -4,19 +4,10 @@ import { motion, useReducedMotion } from 'motion/react';
 
 const signals = ['proofs for AI execution', 'portable memory', 'agent settlement'];
 
-const pipeline = [
-  { k: 'Request', v: 'intent + context' },
-  { k: 'Memory', v: 'portable state' },
-  { k: 'Execute', v: 'GPU + TEE' },
-  { k: 'Prove', v: 'signed output' },
-  { k: 'Settle', v: 'external record' },
-];
-
-const auditItems = [
-  ['model', 'open model'],
-  ['enclave', 'attested'],
-  ['proof', 'ed25519'],
-  ['state', 'committed'],
+const checkItems = [
+  ['model', 'open'],
+  ['run', 'attested'],
+  ['output', 'signed'],
 ];
 
 export default function Hero() {
@@ -137,7 +128,7 @@ export default function Hero() {
 
 function HeroSystemPanel() {
   return (
-    <div className="relative overflow-hidden border-b border-border bg-[linear-gradient(135deg,#ffffff_0%,#f7f7f2_46%,#edf3ff_100%)] p-5">
+    <div className="relative overflow-hidden border-b border-border bg-[linear-gradient(135deg,#ffffff_0%,#f7f7f2_46%,#edf3ff_100%)] p-5 sm:p-6">
       <div
         aria-hidden
         className="absolute inset-0 opacity-70 [background-image:linear-gradient(to_right,rgba(36,70,199,0.08)_1px,transparent_1px),linear-gradient(to_bottom,rgba(15,118,110,0.07)_1px,transparent_1px)] [background-size:24px_24px]"
@@ -154,10 +145,10 @@ function HeroSystemPanel() {
       <div className="relative z-10 flex items-center justify-between gap-4">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-            Agent audit trail
+            Agent run
           </div>
-          <p className="mt-2 max-w-[18rem] font-serif text-[22px] leading-[1.08] text-fg">
-            Accountable agents, not smarter chat windows.
+          <p className="mt-2 max-w-[18rem] font-serif text-[22px] leading-[1.08] text-fg sm:text-[24px]">
+            Agents that can be checked after they act.
           </p>
         </div>
         <span className="hidden rounded-[2px] border border-border bg-surface/90 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-accent sm:inline-flex">
@@ -165,34 +156,64 @@ function HeroSystemPanel() {
         </span>
       </div>
 
-      <div className="relative z-10 mt-5 grid gap-2">
-        {pipeline.map((step, index) => (
-          <div
-            key={step.k}
-            className="grid grid-cols-[2.1rem_minmax(0,1fr)_auto] items-center gap-3 rounded-[2px] border border-border bg-surface/82 px-3 py-2 shadow-[0_1px_0_rgba(29,37,40,0.03)]"
-          >
-            <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-accent-alt">
-              {String(index + 1).padStart(2, '0')}
-            </span>
-            <div className="min-w-0">
-              <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
-                {step.k}
-              </div>
-              <div className="mt-0.5 truncate font-serif text-[13px] leading-tight text-fg-muted">
-                {step.v}
-              </div>
-            </div>
-            <span
-              aria-hidden
-              className={`h-2 w-2 rounded-full ${index === 3 ? 'bg-accent' : 'bg-accent-alt/60'}`}
-            />
-          </div>
-        ))}
+      <div className="relative z-10 mt-5 h-[252px] overflow-hidden border border-border bg-surface/70 shadow-[0_1px_0_rgba(29,37,40,0.03)]">
+        <svg
+          aria-hidden
+          viewBox="0 0 380 252"
+          className="absolute inset-0 h-full w-full"
+          preserveAspectRatio="none"
+        >
+          <defs>
+            <linearGradient id="agent-line" x1="0" x2="1" y1="0" y2="1">
+              <stop offset="0%" stopColor="#2446c7" stopOpacity="0.78" />
+              <stop offset="100%" stopColor="#0f766e" stopOpacity="0.58" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M 70 64 C 126 35, 188 38, 227 73 C 266 108, 260 154, 218 181 C 176 208, 111 197, 80 158 C 48 118, 36 84, 70 64 Z"
+            fill="none"
+            stroke="#c6d4f5"
+            strokeWidth="1.2"
+          />
+          <path
+            d="M 74 72 C 128 58, 156 72, 184 104"
+            fill="none"
+            stroke="url(#agent-line)"
+            strokeWidth="1.7"
+          />
+          <path
+            d="M 217 116 C 251 122, 281 132, 304 155"
+            fill="none"
+            stroke="url(#agent-line)"
+            strokeWidth="1.7"
+          />
+          <path
+            d="M 169 158 C 141 172, 111 169, 84 148"
+            fill="none"
+            stroke="#0f766e"
+            strokeOpacity="0.48"
+            strokeWidth="1.4"
+            strokeDasharray="4 5"
+          />
+          <circle cx="190" cy="126" r="42" fill="#edf3ff" stroke="#2446c7" strokeOpacity="0.35" />
+          <circle cx="190" cy="126" r="21" fill="#ffffff" stroke="#2446c7" strokeOpacity="0.45" />
+          <path d="M 179 126 L 188 135 L 204 115" fill="none" stroke="#2446c7" strokeWidth="2.2" />
+          <circle cx="74" cy="72" r="4" fill="#2446c7" />
+          <circle cx="184" cy="104" r="4" fill="#0f766e" />
+          <circle cx="304" cy="155" r="4" fill="#2446c7" />
+          <circle cx="84" cy="148" r="4" fill="#0f766e" />
+        </svg>
+
+        <DiagramLabel className="left-4 top-4" k="Request" v="intent + context" />
+        <DiagramLabel className="bottom-5 left-5" k="Memory" v="portable state" />
+        <DiagramLabel className="left-1/2 top-1/2 w-[8.4rem] -translate-x-1/2 translate-y-[3.1rem] text-center" k="TEE run" v="model output" />
+        <DiagramLabel className="right-4 top-6 text-right" k="Proof" v="signed output" />
+        <DiagramLabel className="bottom-5 right-4 text-right" k="Settlement" v="external record" />
       </div>
 
-      <dl className="relative z-10 mt-4 grid grid-cols-2 gap-2">
-        {auditItems.map(([k, v]) => (
-          <div key={k} className="border-y border-border bg-bg/70 px-3 py-2">
+      <dl className="relative z-10 mt-4 grid grid-cols-3 border-y border-border bg-bg/60">
+        {checkItems.map(([k, v]) => (
+          <div key={k} className="border-r border-border px-3 py-2.5 last:border-r-0">
             <dt className="font-mono text-[8.5px] uppercase tracking-[0.14em] text-fg-dim">
               {k}
             </dt>
@@ -202,6 +223,19 @@ function HeroSystemPanel() {
           </div>
         ))}
       </dl>
+    </div>
+  );
+}
+
+function DiagramLabel({ className, k, v }) {
+  return (
+    <div className={`absolute z-10 max-w-[8.5rem] ${className}`}>
+      <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
+        {k}
+      </div>
+      <div className="mt-1 font-serif text-[13px] leading-tight text-fg-muted">
+        {v}
+      </div>
     </div>
   );
 }

--- a/src/components/ImpactLedger.js
+++ b/src/components/ImpactLedger.js
@@ -1,0 +1,126 @@
+import Reveal from './Reveal';
+import SectionHeader from './SectionHeader';
+
+const entries = [
+  {
+    year: '2026',
+    arena: 'OpenGradient',
+    result: 'Took a new AI infrastructure product from zero to seven figures in revenue.',
+    role: 'Product strategy, customer engineering, enterprise motion',
+    proof: 'Network scaled across hosted models, inference volume, and signed proofs.',
+  },
+  {
+    year: '2026',
+    arena: 'Market entry',
+    result: 'Launched OpenGradient into Korea with 1,000+ event attendees in a week.',
+    role: 'Regional GTM, community design, ecosystem partnerships',
+    proof: 'Builder community activation and Korean press coverage.',
+  },
+  {
+    year: '2025',
+    arena: 'Distribution',
+    result: 'Built a film-led campaign that pushed OpenGradient past 50M+ X views.',
+    role: 'Producer, director, writer',
+    proof: 'Technical narrative translated into a repeatable media surface.',
+  },
+  {
+    year: '2024',
+    arena: 'Research',
+    result: 'Published The State of Edge AI with 174K+ launch impressions and citations.',
+    role: 'First author, market synthesis, technical writing',
+    proof: 'Edge AI thesis used by builders, investors, and researchers.',
+  },
+  {
+    year: '2022',
+    arena: 'Founder track',
+    result: 'Built SuperSight / Peri Labs to 200K+ users and 30+ enterprise pilots.',
+    role: 'Founder, product architect, NL-to-SQL pipeline',
+    proof: '$1.5M pre-seed at $30M; IP later acquired.',
+  },
+];
+
+const capabilities = [
+  'Turn frontier research into a market narrative.',
+  'Ship technical product with customer-facing credibility.',
+  'Build trust surfaces around opaque AI execution.',
+  'Move between engineering, capital, ecosystem, and media.',
+];
+
+export default function ImpactLedger() {
+  return (
+    <section
+      id="impact"
+      className="relative border-t border-border bg-surface/35 py-16 sm:py-24 md:py-32 lg:py-40"
+    >
+      <div className="mx-auto max-w-6xl px-5 sm:px-8">
+        <SectionHeader
+          index="03"
+          title="Impact"
+          lede="The work compounds when technical depth, distribution, and trust design point in the same direction."
+        />
+
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-16">
+          <Reveal>
+            <aside className="lg:sticky lg:top-28">
+              <div className="border-y border-border py-6">
+                <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                  What this site should make obvious
+                </div>
+                <p className="mt-5 font-serif text-[21px] leading-[1.4] text-fg sm:text-[27px]">
+                  I am strongest where the product is technical, the market is early, and the
+                  story has to become credible before it becomes obvious.
+                </p>
+              </div>
+
+              <ul className="mt-7 divide-y divide-border-soft border-b border-border">
+                {capabilities.map((item) => (
+                  <li
+                    key={item}
+                    className="grid grid-cols-[1.4rem_1fr] gap-3 py-4 font-serif text-[15px] leading-[1.5] text-fg-muted"
+                  >
+                    <span aria-hidden className="font-mono text-[10px] text-accent-alt">
+                      /
+                    </span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </aside>
+          </Reveal>
+
+          <div className="divide-y divide-border">
+            {entries.map((entry, index) => (
+              <Reveal key={`${entry.year}-${entry.arena}`} delay={index * 0.04}>
+                <article className="group grid gap-4 py-7 first:pt-0 last:pb-0 sm:grid-cols-[5rem_1fr] sm:gap-7">
+                  <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent-alt sm:pt-1">
+                    {entry.year}
+                  </div>
+                  <div>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                      <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                        {entry.arena}
+                      </h3>
+                      <span
+                        aria-hidden
+                        className="hidden h-px w-8 bg-accent/35 sm:inline-block"
+                      />
+                      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-fg-dim">
+                        {entry.role}
+                      </p>
+                    </div>
+                    <p className="mt-3 max-w-3xl font-serif text-2xl leading-[1.2] text-fg transition-colors group-hover:text-accent sm:text-[30px]">
+                      {entry.result}
+                    </p>
+                    <p className="mt-3 max-w-2xl font-serif text-[15px] leading-[1.6] text-fg-muted">
+                      {entry.proof}
+                    </p>
+                  </div>
+                </article>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ImpactLedger.js
+++ b/src/components/ImpactLedger.js
@@ -21,7 +21,7 @@ const entries = [
     arena: 'Distribution',
     result: 'Built a film-led campaign that pushed OpenGradient past 50M+ X views.',
     role: 'Producer, director, writer',
-    proof: 'Technical narrative translated into a repeatable media surface.',
+    proof: 'A technical thesis turned into something people could watch and share.',
   },
   {
     year: '2024',
@@ -40,9 +40,9 @@ const entries = [
 ];
 
 const capabilities = [
-  'Turn frontier research into a market narrative.',
-  'Ship technical product with customer-facing credibility.',
-  'Build trust surfaces around opaque AI execution.',
+  'Turn new research into a story a market can understand.',
+  'Ship technical product with real customer proof.',
+  'Make opaque AI execution easier to audit.',
   'Move between engineering, capital, ecosystem, and media.',
 ];
 
@@ -56,7 +56,7 @@ export default function ImpactLedger() {
         <SectionHeader
           index="03"
           title="Impact"
-          lede="The work compounds when technical depth, distribution, and trust design point in the same direction."
+          lede="I do my best work when the product is technical, the market is early, and the story is still hard to explain."
         />
 
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-16">
@@ -64,11 +64,11 @@ export default function ImpactLedger() {
             <aside className="lg:sticky lg:top-28">
               <div className="border-y border-border py-6">
                 <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-                  What this site should make obvious
+                  Where I&apos;m useful
                 </div>
                 <p className="mt-5 font-serif text-[21px] leading-[1.4] text-fg sm:text-[27px]">
-                  I am strongest where the product is technical, the market is early, and the
-                  story has to become credible before it becomes obvious.
+                  I like the messy middle: the product works, the market is not fully there yet,
+                  and someone has to make the whole thing credible.
                 </p>
               </div>
 

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 const links = [
   { href: '#thesis', label: 'Thesis' },
+  { href: '#impact', label: 'Impact' },
   { href: '#experience', label: 'Experience' },
   { href: '#work', label: 'Work' },
   { href: '#speaking', label: 'Speaking' },
@@ -97,7 +98,7 @@ export default function Nav() {
           </a>
 
           <nav className="hidden md:block" aria-label="Primary navigation">
-            <ul className="flex items-center gap-7">
+            <ul className="flex items-center gap-6">
               {links.map((l) => (
                 <li key={l.href}>
                   <a

--- a/src/components/ProofStrip.js
+++ b/src/components/ProofStrip.js
@@ -13,22 +13,19 @@ export default function ProofStrip() {
     <section aria-label="Selected proof points" className="border-t border-border bg-surface/45">
       <div className="mx-auto max-w-6xl px-5 sm:px-8">
         <Reveal>
-          <div className="border-x border-border">
-            <div className="grid gap-4 border-b border-border px-4 py-4 sm:grid-cols-[9rem_1fr] sm:gap-8 sm:px-5">
+          <div className="grid grid-cols-2 border-x border-border lg:grid-cols-[1.25fr_repeat(5,minmax(0,1fr))]">
+            <div className="col-span-2 border-b border-r border-border px-4 py-5 sm:px-5 lg:col-span-1 lg:border-b-0">
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
                 Receipts
               </div>
-              <p className="max-w-3xl font-serif text-[15px] leading-[1.55] text-fg-muted sm:text-base">
-                Hard outcomes matter on a personal site. These are the numbers the rest of the page
-                has to earn.
+              <p className="mt-2 max-w-sm font-serif text-[14px] leading-[1.45] text-fg-muted">
+                Hard outcomes the rest of the page has to earn.
               </p>
             </div>
-          </div>
-          <dl className="grid grid-cols-2 border-x border-border sm:grid-cols-5">
             {proof.map((item) => (
-              <div
+              <dl
                 key={item.label}
-                className="border-b border-r border-border px-4 py-5 last:border-r-0 sm:border-b-0 sm:px-5 sm:py-6"
+                className="border-b border-r border-border px-4 py-5 last:border-r-0 lg:border-b-0 lg:px-5 lg:py-6"
               >
                 <dt className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-fg-muted">
                   {item.label}
@@ -39,9 +36,9 @@ export default function ProofStrip() {
                 <dd className="mt-2 font-serif text-[13px] leading-snug text-fg-dim">
                   {item.detail}
                 </dd>
-              </div>
+              </dl>
             ))}
-          </dl>
+          </div>
         </Reveal>
       </div>
     </section>

--- a/src/components/ProofStrip.js
+++ b/src/components/ProofStrip.js
@@ -1,10 +1,10 @@
 import Reveal from './Reveal';
 
 const proof = [
-  { value: '7 figures', label: 'AI infra revenue', detail: 'new product motion' },
-  { value: '4,500+', label: 'hosted models', detail: 'network surface area' },
+  { value: '7 figures', label: 'AI infra revenue', detail: 'new product line' },
+  { value: '4,500+', label: 'hosted models', detail: 'model coverage' },
   { value: '2M+', label: 'network inferences', detail: 'execution volume' },
-  { value: '500K+', label: 'verifiable proofs', detail: 'signed receipts' },
+  { value: '500K+', label: 'verifiable proofs', detail: 'signed outputs' },
   { value: '50M+', label: 'campaign views', detail: 'technical narrative' },
 ];
 
@@ -16,10 +16,10 @@ export default function ProofStrip() {
           <div className="grid grid-cols-2 border-x border-border lg:grid-cols-[1.25fr_repeat(5,minmax(0,1fr))]">
             <div className="col-span-2 border-b border-r border-border px-4 py-5 sm:px-5 lg:col-span-1 lg:border-b-0">
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-                Receipts
+                A few numbers
               </div>
               <p className="mt-2 max-w-sm font-serif text-[14px] leading-[1.45] text-fg-muted">
-                Hard outcomes the rest of the page has to earn.
+                The numbers behind the rest of the page.
               </p>
             </div>
             {proof.map((item) => (

--- a/src/components/ProofStrip.js
+++ b/src/components/ProofStrip.js
@@ -1,11 +1,11 @@
 import Reveal from './Reveal';
 
 const proof = [
-  { value: '7 figures', label: 'AI infra product revenue' },
-  { value: '4,500+', label: 'hosted models' },
-  { value: '2M+', label: 'network inferences' },
-  { value: '500K+', label: 'verifiable proofs' },
-  { value: '50M+', label: 'campaign views' },
+  { value: '7 figures', label: 'AI infra revenue', detail: 'new product motion' },
+  { value: '4,500+', label: 'hosted models', detail: 'network surface area' },
+  { value: '2M+', label: 'network inferences', detail: 'execution volume' },
+  { value: '500K+', label: 'verifiable proofs', detail: 'signed receipts' },
+  { value: '50M+', label: 'campaign views', detail: 'technical narrative' },
 ];
 
 export default function ProofStrip() {
@@ -13,6 +13,17 @@ export default function ProofStrip() {
     <section aria-label="Selected proof points" className="border-t border-border bg-surface/45">
       <div className="mx-auto max-w-6xl px-5 sm:px-8">
         <Reveal>
+          <div className="border-x border-border">
+            <div className="grid gap-4 border-b border-border px-4 py-4 sm:grid-cols-[9rem_1fr] sm:gap-8 sm:px-5">
+              <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                Receipts
+              </div>
+              <p className="max-w-3xl font-serif text-[15px] leading-[1.55] text-fg-muted sm:text-base">
+                Hard outcomes matter on a personal site. These are the numbers the rest of the page
+                has to earn.
+              </p>
+            </div>
+          </div>
           <dl className="grid grid-cols-2 border-x border-border sm:grid-cols-5">
             {proof.map((item) => (
               <div
@@ -24,6 +35,9 @@ export default function ProofStrip() {
                 </dt>
                 <dd className="mt-2 font-serif text-2xl leading-none text-fg sm:text-3xl">
                   {item.value}
+                </dd>
+                <dd className="mt-2 font-serif text-[13px] leading-snug text-fg-dim">
+                  {item.detail}
                 </dd>
               </div>
             ))}

--- a/src/components/Speaking.js
+++ b/src/components/Speaking.js
@@ -44,60 +44,87 @@ const talks = [
   },
 ];
 
+const topics = [
+  'Agentic internet',
+  'Open intelligence',
+  'Verifiable compute',
+  'AI x crypto market structure',
+];
+
 export default function Speaking() {
   return (
     <section id="speaking" className="relative py-16 sm:py-24 md:py-32 lg:py-40 border-t border-border">
       <div className="mx-auto max-w-6xl px-5 sm:px-8">
         <SectionHeader
-          index="05"
+          index="06"
           title="Speaking"
           lede="Selected rooms where I've explained the agentic internet, open intelligence, and verifiable compute."
         />
 
-        <ul>
-          {talks.map((t, i) => (
-            <Reveal key={t.title} delay={i * 0.03}>
-              <li className="border-t border-border first:border-t-0">
-                {t.href ? (
-                  <a
-                    href={t.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`${t.title} at ${t.v} (opens in a new tab)`}
-                    className="group grid gap-2 md:grid-cols-12 md:gap-10 py-5 sm:py-6 transition-colors hover:bg-surface-soft/60 -mx-4 px-4 sm:-mx-6 sm:px-6"
+        <div className="grid gap-10 lg:grid-cols-[260px_1fr] lg:gap-14">
+          <Reveal>
+            <aside className="border-y border-border py-5 lg:sticky lg:top-28">
+              <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+                Speaking lanes
+              </div>
+              <ul className="mt-4 flex flex-wrap gap-2 lg:flex-col">
+                {topics.map((topic) => (
+                  <li
+                    key={topic}
+                    className="rounded-[2px] border border-border bg-surface px-2.5 py-1.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-fg-muted"
                   >
-                    <div className="md:col-span-3 font-mono text-[11px] uppercase tracking-[0.12em] text-accent md:pt-1.5">
-                      {t.v}
-                    </div>
-                    <div className="md:col-span-9">
-                      <div className="font-serif text-lg sm:text-xl md:text-2xl text-fg leading-snug group-hover:text-accent transition-colors">
-                        {t.title}
-                        <span aria-hidden className="ml-2 inline-block text-fg-faint transition-transform group-hover:translate-x-0.5">↗</span>
+                    {topic}
+                  </li>
+                ))}
+              </ul>
+            </aside>
+          </Reveal>
+
+          <ul>
+            {talks.map((t, i) => (
+              <Reveal key={t.title} delay={i * 0.03}>
+                <li className="border-t border-border first:border-t-0">
+                  {t.href ? (
+                    <a
+                      href={t.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`${t.title} at ${t.v} (opens in a new tab)`}
+                      className="group grid gap-2 py-5 transition-colors hover:bg-surface-soft/60 md:grid-cols-12 md:gap-10 sm:py-6 -mx-4 px-4 sm:-mx-6 sm:px-6"
+                    >
+                      <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-accent md:col-span-3 md:pt-1.5">
+                        {t.v}
                       </div>
-                      <div className="mt-1 font-serif italic text-[15px] text-fg-muted leading-relaxed">
-                        {t.d}
+                      <div className="md:col-span-9">
+                        <div className="font-serif text-lg leading-snug text-fg transition-colors group-hover:text-accent sm:text-xl md:text-2xl">
+                          {t.title}
+                          <span aria-hidden className="ml-2 inline-block text-fg-faint transition-transform group-hover:translate-x-0.5">↗</span>
+                        </div>
+                        <div className="mt-1 font-serif italic text-[15px] leading-relaxed text-fg-muted">
+                          {t.d}
+                        </div>
+                      </div>
+                    </a>
+                  ) : (
+                    <div className="grid gap-2 py-5 md:grid-cols-12 md:gap-10 sm:py-6 -mx-4 px-4 sm:-mx-6 sm:px-6">
+                      <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-accent md:col-span-3 md:pt-1.5">
+                        {t.v}
+                      </div>
+                      <div className="md:col-span-9">
+                        <div className="font-serif text-lg leading-snug text-fg sm:text-xl md:text-2xl">
+                          {t.title}
+                        </div>
+                        <div className="mt-1 font-serif italic text-[15px] leading-relaxed text-fg-muted">
+                          {t.d}
+                        </div>
                       </div>
                     </div>
-                  </a>
-                ) : (
-                  <div className="grid gap-2 md:grid-cols-12 md:gap-10 py-5 sm:py-6 -mx-4 px-4 sm:-mx-6 sm:px-6">
-                    <div className="md:col-span-3 font-mono text-[11px] uppercase tracking-[0.12em] text-accent md:pt-1.5">
-                      {t.v}
-                    </div>
-                    <div className="md:col-span-9">
-                      <div className="font-serif text-lg sm:text-xl md:text-2xl text-fg leading-snug">
-                        {t.title}
-                      </div>
-                      <div className="mt-1 font-serif italic text-[15px] text-fg-muted leading-relaxed">
-                        {t.d}
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </li>
-            </Reveal>
-          ))}
-        </ul>
+                  )}
+                </li>
+              </Reveal>
+            ))}
+          </ul>
+        </div>
       </div>
     </section>
   );

--- a/src/components/Speaking.js
+++ b/src/components/Speaking.js
@@ -58,14 +58,14 @@ export default function Speaking() {
         <SectionHeader
           index="06"
           title="Speaking"
-          lede="Selected rooms where I've explained the agentic internet, open intelligence, and verifiable compute."
+          lede="Talks and conversations on agents, open intelligence, and verifiable compute."
         />
 
         <div className="grid gap-10 lg:grid-cols-[260px_1fr] lg:gap-14">
           <Reveal>
             <aside className="border-y border-border py-5 lg:sticky lg:top-28">
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-                Speaking lanes
+                Topics
               </div>
               <ul className="mt-4 flex flex-wrap gap-2 lg:flex-col">
                 {topics.map((topic) => (

--- a/src/components/StructuredData.js
+++ b/src/components/StructuredData.js
@@ -25,9 +25,11 @@ const data = {
       ],
       knowsAbout: [
         'Verifiable AI inference',
+        'Accountable AI agents',
         'Agent memory',
         'Decentralized AI infrastructure',
         'Crypto market structure',
+        'Technical product strategy',
       ],
       sameAs: Object.values(socialLinks),
     },

--- a/src/components/Thesis.js
+++ b/src/components/Thesis.js
@@ -6,17 +6,25 @@ const pillars = [
     k: 'Trust surface',
     v: 'Inference should carry receipts.',
     d: 'When an agent makes a claim, executes a trade, or touches user state, the system should be able to prove what model ran, where it ran, and what it returned.',
+    proof: 'TEE attestation, signed outputs, verifiable execution trails',
   },
   {
     k: 'Memory layer',
     v: 'Context should outlive the chat window.',
     d: 'Useful agents need portable memory across models, sessions, and interfaces without trapping users inside one closed assistant.',
+    proof: 'MemSync-style context that can move across models and products',
   },
   {
     k: 'Settlement layer',
     v: 'High-stakes actions need neutral rails.',
     d: 'The moment agents move money, reputation, or access, settlement has to be inspectable, programmable, and hard for the operator to quietly rewrite.',
+    proof: 'On-chain commitments for actions that need external accountability',
   },
+];
+
+const beforeAfter = [
+  ['Today', 'black-box assistants', 'trust me'],
+  ['Next', 'accountable operators', 'verify this'],
 ];
 
 export default function Thesis() {
@@ -29,7 +37,7 @@ export default function Thesis() {
           lede="AI agents are becoming operators. The infrastructure around them still behaves like a black box."
         />
 
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] lg:gap-16">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)] lg:gap-16">
           <Reveal>
             <div className="border-y border-border py-6">
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
@@ -43,26 +51,49 @@ export default function Thesis() {
                 That means verifiable execution, memory that users can carry, and economic rails
                 that make agent actions legible after the fact.
               </p>
+
+              <dl className="mt-8 divide-y divide-border-soft border-y border-border">
+                {beforeAfter.map(([label, system, promise]) => (
+                  <div
+                    key={label}
+                    className="grid grid-cols-[4.5rem_1fr] gap-4 py-4 sm:grid-cols-[5.5rem_1fr_6rem]"
+                  >
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent-alt">
+                      {label}
+                    </dt>
+                    <dd className="font-serif text-[16px] leading-snug text-fg">{system}</dd>
+                    <dd className="font-mono text-[10px] uppercase tracking-[0.14em] text-fg-muted sm:text-right">
+                      {promise}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
             </div>
           </Reveal>
 
           <Reveal>
-            <ol className="divide-y divide-border">
+            <ol className="grid gap-4">
               {pillars.map((pillar, index) => (
-                <li key={pillar.k} className="grid gap-4 py-6 first:pt-0 last:pb-0 sm:grid-cols-[4rem_1fr]">
-                  <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt">
+                <li
+                  key={pillar.k}
+                  className="group grid gap-5 rounded-[3px] border border-border bg-surface px-5 py-5 transition-all hover:border-accent hover:shadow-[0_18px_50px_rgba(29,37,40,0.06)] sm:grid-cols-[4rem_1fr] sm:px-6 sm:py-6"
+                >
+                  <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt sm:pt-1">
                     {String(index + 1).padStart(2, '0')}
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
                       {pillar.k}
                     </div>
-                    <h3 className="mt-2 font-serif text-2xl leading-snug text-fg">
+                    <h3 className="mt-2 font-serif text-2xl leading-snug text-fg transition-colors group-hover:text-accent">
                       {pillar.v}
                     </h3>
                     <p className="mt-3 max-w-2xl font-serif text-[15px] leading-[1.6] text-fg-muted">
                       {pillar.d}
                     </p>
+                    <div className="mt-5 border-l border-accent/35 pl-4 font-serif text-[14px] leading-[1.45] text-fg-dim">
+                      {pillar.proof}
+                    </div>
                   </div>
                 </li>
               ))}

--- a/src/components/Thesis.js
+++ b/src/components/Thesis.js
@@ -3,8 +3,8 @@ import SectionHeader from './SectionHeader';
 
 const pillars = [
   {
-    k: 'Trust surface',
-    v: 'Inference should carry receipts.',
+    k: 'Trust layer',
+    v: 'Inference should be checkable.',
     d: 'When an agent makes a claim, executes a trade, or touches user state, the system should be able to prove what model ran, where it ran, and what it returned.',
     proof: 'TEE attestation, signed outputs, verifiable execution trails',
   },
@@ -49,7 +49,7 @@ export default function Thesis() {
               </p>
               <p className="mt-5 font-serif text-base leading-[1.65] text-fg-muted sm:text-[17px]">
                 That means verifiable execution, memory that users can carry, and economic rails
-                that make agent actions legible after the fact.
+                that make agent actions auditable later.
               </p>
 
               <dl className="mt-8 divide-y divide-border-soft border-y border-border">

--- a/src/components/Work.js
+++ b/src/components/Work.js
@@ -1,13 +1,17 @@
+import Image from 'next/image';
 import Reveal from './Reveal';
 import SectionHeader from './SectionHeader';
 
 const items = [
   {
     num: '01',
-    label: 'Film',
+    label: 'Campaign system',
     title: 'OpenGradient — film work',
-    desc: 'Producer, director, writer. Part of the campaign that took the OpenGradient X account past 50M+ views.',
-    impact: '50M+ views',
+    desc: 'Producer, director, writer. A technical media campaign designed to make open intelligence feel tangible, not abstract.',
+    impact: '50M+ views · launch narrative',
+    featured: true,
+    image: '/images/ascii_bg.gif',
+    signals: ['narrative strategy', 'technical distribution', 'brand surface'],
     links: [
       { label: 'Flagship', href: 'https://x.com/OpenGradient/status/2045849964539171274' },
       { label: 'Film II', href: 'https://x.com/OpenGradient/status/2053766717474492927' },
@@ -20,6 +24,7 @@ const items = [
     title: 'The State of Edge AI',
     desc: 'First author. Real-time data, privacy, and deployment strategies for large models at the edge. 174K+ X impressions, 6 academic citations.',
     impact: '174K+ impressions',
+    signals: ['edge AI', 'market map'],
     links: [
       { label: 'PDF', href: 'https://peri-labs.github.io/docs/assets/files/The_State_of_Edge_AI.pdf' },
       { label: 'Launch tweet', href: 'https://x.com/advait_jayant/status/1844420752323510351' },
@@ -31,6 +36,7 @@ const items = [
     title: 'The AiFi Thesis',
     desc: 'A framework for combining AI and DeFi to tokenize computation, training data, and ML models.',
     impact: 'AI x DeFi thesis',
+    signals: ['crypto rails', 'compute markets'],
     href: 'https://peri-labs.github.io/docs/assets/files/The_AiFi_Thesis.pdf',
   },
   {
@@ -39,6 +45,7 @@ const items = [
     title: 'The Economics of Wash Trading',
     desc: 'Microstructure and incentive design behind manufactured volume in digital-asset markets.',
     impact: 'Market structure',
+    signals: ['market design', 'incentives'],
     href: 'https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4610162',
   },
   {
@@ -47,6 +54,7 @@ const items = [
     title: 'FHE for Consensus in AI Models',
     desc: 'Using fully-homomorphic encryption to coordinate trustless consensus across model outputs.',
     impact: 'Verifiable compute',
+    signals: ['FHE', 'model consensus'],
     href: 'https://www.youtube.com/watch?v=4s_IhcMoOks',
   },
 ];
@@ -56,14 +64,14 @@ export default function Work() {
     <section id="work" className="relative py-16 sm:py-24 md:py-32 lg:py-40 border-t border-border bg-surface/40">
       <div className="mx-auto max-w-6xl px-5 sm:px-8">
         <SectionHeader
-          index="04"
+          index="05"
           title="Selected work"
           lede="Research, media, and talks that move technical ideas into the market."
         />
 
         <div className="grid gap-5 sm:gap-6 sm:grid-cols-2">
           {items.map((it, i) => (
-            <Reveal key={it.title} delay={i * 0.04}>
+            <Reveal key={it.title} delay={i * 0.04} className={it.featured ? 'sm:col-span-2' : undefined}>
               <Card item={it} />
             </Reveal>
           ))}
@@ -77,56 +85,101 @@ function Card({ item }) {
   // Primary link = item.href OR the first item.links entry.
   const primaryHref = item.href ?? item.links?.[0]?.href;
   const primaryLabel = item.href ? item.title : `${item.title} — ${item.links?.[0]?.label}`;
+  const isFeatured = item.featured;
 
   return (
-    <div className="group relative flex h-full min-h-[250px] flex-col overflow-hidden rounded-[3px] border border-border bg-surface p-6 transition-all hover:-translate-y-0.5 hover:border-accent hover:shadow-[0_18px_50px_rgba(29,37,40,0.06)] focus-within:border-accent sm:p-7 md:p-8">
+    <div
+      className={`group relative flex h-full min-h-[250px] flex-col overflow-hidden rounded-[3px] border border-border bg-surface transition-all hover:-translate-y-0.5 hover:border-accent hover:shadow-[0_18px_50px_rgba(29,37,40,0.06)] focus-within:border-accent ${
+        isFeatured ? 'md:grid md:min-h-[330px] md:grid-cols-[0.92fr_1.08fr]' : 'p-6 sm:p-7 md:p-8'
+      }`}
+    >
       <div aria-hidden className="absolute inset-x-0 top-0 h-1 bg-accent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" />
-      <div className="relative z-10 flex items-center justify-between font-mono text-[10.5px] uppercase tracking-[0.12em] text-accent">
-        <span>
-          <span className="text-accent">{item.num}</span>
-          <span className="text-fg-faint mx-2">·</span>
-          <span>{item.label}</span>
-        </span>
-        {/* Stretched anchor — clicking anywhere on the card opens the primary link */}
-        <a
-          href={primaryHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={`${primaryLabel} (opens in a new tab)`}
-          className="text-fg-faint group-hover:text-accent transition-colors before:content-[''] before:absolute before:inset-0 before:z-0 focus-visible:outline-offset-4"
-        >
-          <span aria-hidden>↗</span>
-        </a>
-      </div>
 
-      <h3 className="relative z-10 mt-4 sm:mt-5 font-serif text-2xl sm:text-[28px] md:text-[30px] leading-[1.1] text-fg group-hover:text-accent transition-colors">
-        {item.title}
-      </h3>
-      <p className="relative z-10 mt-3 font-serif text-[14.5px] sm:text-[15px] leading-[1.55] text-fg-muted">
-        {item.desc}
-      </p>
-
-      <div className="relative z-10 mt-5 inline-flex w-fit border-y border-border py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt">
-        {item.impact}
-      </div>
-
-      {item.links && (
-        <div className="relative z-10 mt-auto pt-6 flex flex-wrap gap-2">
-          {item.links.map((l) => (
-            <a
-              key={l.href}
-              href={l.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`${l.label} for ${item.title} (opens in a new tab)`}
-              className="group/pill inline-flex items-center gap-1.5 rounded-[3px] border border-border bg-bg px-3.5 py-2 min-h-[36px] font-mono text-[10.5px] uppercase tracking-[0.12em] text-fg-muted hover:border-accent hover:text-accent transition-colors"
-            >
-              {l.label}
-              <span aria-hidden className="text-fg-faint group-hover/pill:text-accent transition-colors">↗</span>
-            </a>
-          ))}
+      {item.image && (
+        <div className="relative min-h-[210px] border-b border-border md:min-h-full md:border-b-0 md:border-r">
+          <Image
+            src={item.image}
+            alt=""
+            fill
+            unoptimized
+            sizes="(min-width: 768px) 470px, 100vw"
+            className="object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-br from-bg/5 via-bg/15 to-bg/80" />
+          <div className="absolute bottom-4 left-4 right-4 flex items-end justify-between gap-4">
+            <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+              Technical media
+            </span>
+            <span className="rounded-[2px] border border-border bg-surface/80 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-accent-alt">
+              50M+
+            </span>
+          </div>
         </div>
       )}
+
+      <div className={`relative flex h-full flex-col ${isFeatured ? 'p-6 sm:p-7 md:p-8' : ''}`}>
+        <div className="relative z-10 flex items-center justify-between font-mono text-[10.5px] uppercase tracking-[0.12em] text-accent">
+          <span>
+            <span className="text-accent">{item.num}</span>
+            <span className="text-fg-faint mx-2">·</span>
+            <span>{item.label}</span>
+          </span>
+          {/* Stretched anchor — clicking anywhere on the card opens the primary link */}
+          <a
+            href={primaryHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${primaryLabel} (opens in a new tab)`}
+            className="text-fg-faint transition-colors before:absolute before:inset-0 before:z-0 before:content-[''] group-hover:text-accent focus-visible:outline-offset-4"
+          >
+            <span aria-hidden>↗</span>
+          </a>
+        </div>
+
+        <h3 className="relative z-10 mt-4 font-serif text-2xl leading-[1.1] text-fg transition-colors group-hover:text-accent sm:mt-5 sm:text-[28px] md:text-[30px]">
+          {item.title}
+        </h3>
+        <p className="relative z-10 mt-3 font-serif text-[14.5px] leading-[1.55] text-fg-muted sm:text-[15px]">
+          {item.desc}
+        </p>
+
+        <div className="relative z-10 mt-5 inline-flex w-fit border-y border-border py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-accent-alt">
+          {item.impact}
+        </div>
+
+        {item.signals && (
+          <div className="relative z-10 mt-5 flex flex-wrap gap-2">
+            {item.signals.map((signal) => (
+              <span
+                key={signal}
+                className="rounded-[2px] border border-border-soft bg-bg px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-fg-dim"
+              >
+                {signal}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {item.links && (
+          <div className="relative z-10 mt-auto flex flex-wrap gap-2 pt-6">
+            {item.links.map((l) => (
+              <a
+                key={l.href}
+                href={l.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`${l.label} for ${item.title} (opens in a new tab)`}
+                className="group/pill inline-flex min-h-[36px] items-center gap-1.5 rounded-[3px] border border-border bg-bg px-3.5 py-2 font-mono text-[10.5px] uppercase tracking-[0.12em] text-fg-muted transition-colors hover:border-accent hover:text-accent"
+              >
+                {l.label}
+                <span aria-hidden className="text-fg-faint transition-colors group-hover/pill:text-accent">
+                  ↗
+                </span>
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Work.js
+++ b/src/components/Work.js
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import Reveal from './Reveal';
 import SectionHeader from './SectionHeader';
 
@@ -10,7 +9,7 @@ const items = [
     desc: 'Producer, director, writer. A technical media campaign designed to make open intelligence feel tangible, not abstract.',
     impact: '50M+ views · launch narrative',
     featured: true,
-    image: '/images/ascii_bg.gif',
+    visual: 'campaign',
     signals: ['narrative strategy', 'technical distribution', 'brand surface'],
     links: [
       { label: 'Flagship', href: 'https://x.com/OpenGradient/status/2045849964539171274' },
@@ -95,27 +94,7 @@ function Card({ item }) {
     >
       <div aria-hidden className="absolute inset-x-0 top-0 h-1 bg-accent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" />
 
-      {item.image && (
-        <div className="relative min-h-[210px] border-b border-border md:min-h-full md:border-b-0 md:border-r">
-          <Image
-            src={item.image}
-            alt=""
-            fill
-            unoptimized
-            sizes="(min-width: 768px) 470px, 100vw"
-            className="object-cover"
-          />
-          <div className="absolute inset-0 bg-gradient-to-br from-bg/5 via-bg/15 to-bg/80" />
-          <div className="absolute bottom-4 left-4 right-4 flex items-end justify-between gap-4">
-            <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
-              Technical media
-            </span>
-            <span className="rounded-[2px] border border-border bg-surface/80 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-accent-alt">
-              50M+
-            </span>
-          </div>
-        </div>
-      )}
+      {item.visual === 'campaign' && <CampaignVisual />}
 
       <div className={`relative flex h-full flex-col ${isFeatured ? 'p-6 sm:p-7 md:p-8' : ''}`}>
         <div className="relative z-10 flex items-center justify-between font-mono text-[10.5px] uppercase tracking-[0.12em] text-accent">
@@ -179,6 +158,91 @@ function Card({ item }) {
             ))}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function CampaignVisual() {
+  const frames = [
+    { k: 'Hook', v: 'Open intelligence enters the room' },
+    { k: 'Proof', v: 'TEE inference becomes visible' },
+    { k: 'Distribution', v: 'The thesis travels' },
+  ];
+
+  return (
+    <div className="relative min-h-[240px] overflow-hidden border-b border-border bg-fg md:min-h-full md:border-b-0 md:border-r">
+      <div
+        aria-hidden
+        className="absolute inset-0 opacity-35 [background-image:linear-gradient(to_right,rgba(255,255,255,0.16)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.09)_1px,transparent_1px)] [background-size:22px_22px]"
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-[radial-gradient(circle_at_68%_42%,rgba(237,243,255,0.5),transparent_28%),radial-gradient(circle_at_18%_72%,rgba(15,118,110,0.22),transparent_32%),linear-gradient(135deg,rgba(36,70,199,0.32),transparent_58%)]"
+      />
+      <div
+        aria-hidden
+        className="absolute -right-12 top-8 h-52 w-52 rounded-full border border-white/20 bg-accent/20"
+      />
+      <div
+        aria-hidden
+        className="absolute bottom-0 left-0 right-0 h-28 bg-gradient-to-t from-fg via-fg/55 to-transparent"
+      />
+
+      <div className="relative z-10 flex h-full min-h-[240px] flex-col justify-between p-5 sm:p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/68">
+              Campaign artifact
+            </div>
+            <p className="mt-2 max-w-[15rem] font-serif text-[25px] leading-[1.02] text-white sm:text-[30px]">
+              Making open intelligence feel cinematic.
+            </p>
+          </div>
+          <span className="rounded-[2px] border border-white/18 bg-white/10 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-white/80">
+            50M+
+          </span>
+        </div>
+
+        <div className="mt-8 grid gap-2">
+          {frames.map((frame, index) => (
+            <div
+              key={frame.k}
+              className="grid grid-cols-[3.5rem_1fr] gap-3 border border-white/16 bg-white/[0.07] px-3 py-2.5 backdrop-blur-[2px]"
+            >
+              <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-accent-soft">
+                F{String(index + 1).padStart(2, '0')}
+              </div>
+              <div>
+                <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-white/70">
+                  {frame.k}
+                </div>
+                <div className="mt-1 font-serif text-[13.5px] leading-snug text-white/82">
+                  {frame.v}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-center gap-2">
+            {[20, 42, 68, 100].map((width, index) => (
+              <div key={width} className="h-px flex-1 bg-white/18">
+                <div
+                  className="h-px bg-accent-soft"
+                  style={{ width: `${index === 3 ? 100 : width}%` }}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3 font-mono text-[9px] uppercase tracking-[0.16em] text-white/62">
+            <span>Write</span>
+            <span>Direct</span>
+            <span>Launch</span>
+            <span>Distribute</span>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Work.js
+++ b/src/components/Work.js
@@ -6,11 +6,11 @@ const items = [
     num: '01',
     label: 'Campaign system',
     title: 'OpenGradient — film work',
-    desc: 'Producer, director, writer. A technical media campaign designed to make open intelligence feel tangible, not abstract.',
+    desc: 'Producer, director, writer. A technical media campaign that made open intelligence feel concrete.',
     impact: '50M+ views · launch narrative',
     featured: true,
     visual: 'campaign',
-    signals: ['narrative strategy', 'technical distribution', 'brand surface'],
+    signals: ['narrative strategy', 'technical distribution', 'brand system'],
     links: [
       { label: 'Flagship', href: 'https://x.com/OpenGradient/status/2045849964539171274' },
       { label: 'Film II', href: 'https://x.com/OpenGradient/status/2053766717474492927' },
@@ -193,10 +193,10 @@ function CampaignVisual() {
         <div className="flex items-start justify-between gap-4">
           <div>
             <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/68">
-              Campaign artifact
+              Campaign board
             </div>
             <p className="mt-2 max-w-[15rem] font-serif text-[25px] leading-[1.02] text-white sm:text-[30px]">
-              Making open intelligence feel cinematic.
+              Making open intelligence feel real.
             </p>
           </div>
           <span className="rounded-[2px] border border-white/18 bg-white/10 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-white/80">

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,7 +1,7 @@
 export const siteUrl = 'https://www.advait.tech';
 export const siteName = 'Advait Jayant';
 export const siteDescription =
-  'Advait Jayant is a technical founder and Chief Strategy Officer at OpenGradient, building verifiable AI infrastructure, portable agent memory, and crypto market structure.';
+  'Advait Jayant is a technical founder and Chief Strategy Officer at OpenGradient, building verifiable AI infrastructure for accountable agents, portable memory, and crypto market structure.';
 
 export const socialLinks = {
   github: 'https://github.com/0xadvait',


### PR DESCRIPTION
## What changed

- Rebuilt the hero into a stronger editorial surface with an animated visual panel and clearer positioning around accountable AI agents.
- Added a dedicated impact ledger that ties outcomes to role, proof, and narrative relevance.
- Expanded the thesis, proof strip, about, experience, work, speaking, and contact sections with stronger hierarchy and clearer calls to action.
- Updated metadata, Open Graph copy, structured data, and anchor behavior.

## Why

The previous pass was too incremental. This pass makes the site feel more like a founder/product narrative: what Advait believes, what he has shipped, why the work matters, and where to engage.

## Validation

- npm run lint
- npm run build
- Desktop and mobile Playwright screenshots against localhost:3001
- Checked hash anchors and horizontal overflow across desktop and mobile viewports
